### PR TITLE
Upgrade to Virtuoso 7.2.8 and use Ubuntu 22.04 as base image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN export VALUE=$(echo $VIRTUOSO_COMMIT | head -c 7); echo "char * git_head = \
 RUN ./autogen.sh
 RUN export CFLAGS="-O2 -m64" \
     && ./configure \
+        --disable-graphql \
         --disable-bpel-vad \
         --enable-conductor-vad \
         --enable-fct-vad \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ RUN wget https://github.com/openlink/virtuoso-opensource/archive/${VIRTUOSO_COMM
 RUN tar xzf ${VIRTUOSO_COMMIT}.tar.gz
 WORKDIR virtuoso-opensource-${VIRTUOSO_COMMIT}
 
+# See https://github.com/openlink/virtuoso-opensource/blob/9cececaca5df32c82576e5390062475bbf5e1cc1/libsrc/Wi/mkgit_head.sh
+# mkgit_head.sh doesn't do what it is expected to do since our downloaded tar doesn't have git history
+# Provide libsrc/Wi/git_head.c manually
+RUN export VALUE=$(echo $VIRTUOSO_COMMIT | head -c 7); echo "#define GIT_HEAD_STR \"$VALUE\"" > libsrc/Wi/git_head.c
+RUN export VALUE=$(echo $VIRTUOSO_COMMIT | head -c 7); echo "char * git_head = \"$VALUE\";" >> libsrc/Wi/git_head.c
+
 # Build virtuoso from source
 RUN ./autogen.sh
 RUN export CFLAGS="-O2 -m64" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM ubuntu:18.04 as builder
+FROM ubuntu:22.04 as builder
 
-# Set Virtuoso commit SHA to Virtuoso 7.2.6.1 release (2021-06-22)
-ARG VIRTUOSO_COMMIT=64663f91c657aec14bbdcef8b6e5c9b6ac89cb8b
+# Set Virtuoso commit SHA to Virtuoso 7.2.8 release (2022-10-19)
+ARG VIRTUOSO_COMMIT=64e6ecd39b03383875b7f2f15ed8070e2ebcd1f0
 
 RUN apt-get update
-# installing libssl1.0-dev instead of libssl1.1 as a Workaround for #663
 RUN apt-get install -y build-essential autotools-dev autoconf automake net-tools libtool \
-                       flex bison gperf gawk m4 libssl1.0-dev libreadline-dev openssl wget
+                       flex bison gperf gawk m4 libssl-dev libreadline-dev openssl wget
 RUN wget https://github.com/openlink/virtuoso-opensource/archive/${VIRTUOSO_COMMIT}.tar.gz
 RUN tar xzf ${VIRTUOSO_COMMIT}.tar.gz
 WORKDIR virtuoso-opensource-${VIRTUOSO_COMMIT}
@@ -29,9 +28,9 @@ RUN export CFLAGS="-O2 -m64" \
     && make && make install
 
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 COPY --from=builder /usr/local/virtuoso-opensource /usr/local/virtuoso-opensource
-RUN apt-get update && apt-get install -y libssl1.0-dev crudini
+RUN apt-get update && apt-get install -y libssl-dev crudini
 # Add Virtuoso bin to the PATH
 ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH
 

--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -82,5 +82,15 @@ then
     kill $(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')
 fi
 
+# NOTE: below command is a workaround for a bug introduced  in 7.2.8
+# see https://community.openlinksw.com/t/sparul-insert-access-denied-even-after-granting-update-permission/3448/9
+# and https://github.com/openlink/virtuoso-opensource/issues/1094
+if [ "$SPARQL_UPDATE" = "true" ];
+then
+  echo "DB.DBA.RDF_DEFAULT_USER_PERMS_SET ('nobody', 7);" > /sql-query.sql
+  virtuoso-t +configfile /tmp/virtuoso.ini +wait && isql-v -U dba -P dba < /sql-query.sql
+  kill "$(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')"
+fi
+
 rm /tmp/virtuoso.ini
 exec virtuoso-t +wait +foreground


### PR DESCRIPTION
Fixes the ssl issue mentioned in https://github.com/redpencilio/docker-virtuoso/pull/8 
Note the small hack to accommodate a new dependency to git (and a git repo) in the build pipeline