### PR TITLE
Correct upstream commit for Virtuoso v7.2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04 as builder
 ARG TARGETPLATFORM
 
 # Set Virtuoso commit SHA to Virtuoso 7.2.10 release (2023-06-07)
-ARG VIRTUOSO_COMMIT=94f76201d9aee9fa3655385ec7f3d45357ad1e75
+ARG VIRTUOSO_COMMIT=f3d88f16bca4274265160e098be3ba3c7d68341c
 
 RUN apt-get update
 RUN apt-get install -y build-essential autotools-dev autoconf automake net-tools libtool \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Docker for hosting Virtuoso.
 
 The Virtuoso is built from a specific commit SHA in https://github.com/openlink/virtuoso-opensource.
-This image is currently build from commit [795af34a7287f064effd91ed251e6bb711f1f5ee](https://github.com/openlink/virtuoso-opensource/commit/795af34a7287f064effd91ed251e6bb711f1f5ee), which corresponds to virtuoso 7.2.9. You can build this image from a different commit by providing the correct commit id as the `VIRTUOSO_COMMIT` [build argument](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg).
+This image is currently build from commit [f3d88f16bca4274265160e098be3ba3c7d68341c](https://github.com/openlink/virtuoso-opensource/commit/f3d88f16bca4274265160e098be3ba3c7d68341c), which corresponds to virtuoso 7.2.10. You can build this image from a different commit by providing the correct commit id as the `VIRTUOSO_COMMIT` [build argument](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg).
 
 ## Running your Virtuoso
     docker run --name my-virtuoso \


### PR DESCRIPTION
Upstream tagged v7.2.10 not on [94f76201](https://github.com/openlink/virtuoso-opensource/commit/94f76201d9aee9fa3655385ec7f3d45357ad1e75), but on a later commit [f3d88f16b](https://github.com/openlink/virtuoso-opensource/commit/f3d88f16bca4274265160e098be3ba3c7d68341c), which seems to be a merge of two development branches: [94f76201](https://github.com/openlink/virtuoso-opensource/commit/94f76201d9aee9fa3655385ec7f3d45357ad1e75) and [d8545421](https://github.com/openlink/virtuoso-opensource/commit/d854542131d63da595f7c5d4a3064876c2a51907).