### PR TITLE
docs: db data must be deleted before restoring backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ docker exec -i virtuoso_container isql-v <<EOF
 ```
 ## Restoring a backup
 
-Backups can be restored either in the running container, or through an environment variable.
+Backups can be restored either in the running container, or through an environment variable. The existing database data must be removed before restoring a backup. You can do this using the following command:
+
+```sh
+rm data/db/virtuoso.{db,trx,pxa} data/db/virtuoso-temp.db data/db/.data_loaded data/db/.dba_pwd_set
+```
 
 Caveat: The following commands mention `backup_` as the base prefix for the backups, this is the whole filename up to (but not including) the ending number and filename extension.  Eg: for a backup including the file `virtuoso_backup_240822T0200-101.bp`, the prefix is `virtuoso_backup_240822T0200-`.
 


### PR DESCRIPTION
Otherwise, Virtuoso logs:

```
app-kaleidos-triplestore-1  | 06:46:27 Remove database file before recovery
app-kaleidos-triplestore-1  | 06:46:27 Could not restore database using prefix backup_
app-kaleidos-triplestore-1  | 06:46:27 Server exiting
```

Although the message should be clear to the user as to what they are required to do, mentioning it specifically in the README might be useful for anyone restoring a backup for the first time (perhaps in a more stressful setting where seeing unexpected logs is the last thing they want to see).