### PR TITLE
Add new SPARQL defaults to Virtuoso.ini

### DIFF
--- a/virtuoso.ini
+++ b/virtuoso.ini
@@ -241,6 +241,7 @@ MaxQueryCostEstimationTime 	= 400	; in seconds
 MaxQueryExecutionTime      	= 60	; in seconds
 DefaultQuery               	= select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    	= 0  ; controls inference rules loading
+MaxMemInUse			= 0  ; limits the amount of memory for construct dict (0=unlimited)
 ;PingService       		= http://rpc.pingthesemanticweb.com/
 
 

--- a/virtuoso.ini
+++ b/virtuoso.ini
@@ -237,6 +237,7 @@ DefaultHost			= localhost:8890
 ;DefaultGraph      		= http://localhost:8890/dataspace
 ;ImmutableGraphs    		= http://localhost:8890/dataspace
 ResultSetMaxRows           	= 10000
+MaxConstructTriples      	  = 10000
 MaxQueryCostEstimationTime 	= 400	; in seconds
 MaxQueryExecutionTime      	= 60	; in seconds
 DefaultQuery               	= select distinct ?Concept where {[] a ?Concept} LIMIT 100


### PR DESCRIPTION
Running the latest release, I've run into some limitations with construct queries that create quite some intermediate data by means of `BIND`'s. I suspect older Virtuoso versions didn't have these settings yet, didn't use to enforce them as they do now, or had different defaults. Tweaking below values managed to solve my problems. Since these default weren't present yet in our `virtuoso.ini`, I added them here as a means of auto-documentation. They should still be tweaked by the user for larger datasets though. 

`D1CTX: Hash dictionary is full, exceeded 10000 entries`
https://github.com/openlink/virtuoso-opensource/issues/1164#issuecomment-1806099766

`Virtuoso 42000 Error D1CT0: Hash dictionary memory pool is full, 200048640 exceeded 200000000 bytes`
https://github.com/openlink/virtuoso-opensource/issues/1021#issuecomment-1085602172
