### PR TITLE
Add VoID description script

### DIFF
--- a/scripts/config.json
+++ b/scripts/config.json
@@ -29,6 +29,22 @@
         "script": "virtuoso/maintenance.sh",
         "join_networks": true
       }
+    },
+    {
+      "documentation": {
+        "command": "create-void-description",
+        "description": "Create a VoID structural data description.\n Parameters:\n  sparql_endpoint: default http://triplestore:8890/sparql\n  graph: default http://mu.semte.ch/graphs/public\n  iri-of-void: default http://mu.semte.ch/.well-known/void#",
+        "arguments": ["sparql-endpoint", "graph", "iri-of-void"]
+      },
+      "environment": {
+        "image": "redpencil/void-generator-docker",
+        "interactive": false,
+        "script": "void-generator/generate_void.sh",
+        "join_networks": true
+      },
+      "mounts": {
+          "app": "/project/"
+        }
     }
   ]
 }

--- a/scripts/void-generator/generate_void.sh
+++ b/scripts/void-generator/generate_void.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SPARQL_ENDPOINT=${1:-"http://triplestore:8890/sparql"}
+GRAPH=${2:-"http://mu.semte.ch/graphs/public"}
+IRI_OF_VOID=${3:-"http://mu.semte.ch/.well-known/void#"}
+
+DATE=`date +%Y%0m%0d%0H%0M%0S`
+FILENAME="void_structural_metadata_${DATE}.ttl"
+DIR="/project/doc/void"
+
+mkdir -p $DIR
+
+echo "Running VoID structural metadata generator on SPARQL endpoint $SPARQL_ENDPOINT for graph $GRAPH"
+java -jar /void-generator.jar \
+    -r "$SPARQL_ENDPOINT" \
+    --void-file "$DIR/$FILENAME" \
+    --iri-of-void "$IRI_OF_VOID" \
+    -g "$GRAPH"


### PR DESCRIPTION
Adds a mu script to generate a [VoID](https://www.w3.org/TR/void/) description from a triplestore graph through SPARQL. Uses https://github.com/JervenBolleman/void-generator through https://github.com/redpencilio/void-generator-docker . 
Note that Virtuoso also has a builting VoID description feature which is documented here https://community.openlinksw.com/t/virtuoso-void-graph-generation/4280 . This implementation isn't nearly as feature-complete or performant as J. Bolleman's implementation however.